### PR TITLE
Support Dark Mode and move to iOS 14+

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Demo/Base.lproj/Main.storyboard
+++ b/Demo/Base.lproj/Main.storyboard
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="14113" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="clX-j4-gDi">
-    <device id="retina4_7" orientation="portrait">
-        <adaptation id="fullscreen"/>
-    </device>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="clX-j4-gDi">
+    <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="14088"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -22,34 +21,40 @@
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <subviews>
                             <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" distribution="equalSpacing" alignment="center" spacing="10" translatesAutoresizingMaskIntoConstraints="NO" id="EQM-gH-Hgi">
-                                <rect key="frame" x="0.0" y="64" width="375" height="530"/>
+                                <rect key="frame" x="0.0" y="44" width="375" height="530"/>
                                 <subviews>
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" alignment="center" translatesAutoresizingMaskIntoConstraints="NO" id="mQR-1B-va6" userLabel="StringPicker Stack View">
                                         <rect key="frame" x="106.5" y="0.0" width="162" height="118"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h1U-9C-Ihc">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="h1U-9C-Ihc">
                                                 <rect key="frame" x="39" y="0.0" width="84" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="UgE-Tb-8Gs"/>
                                                 </constraints>
-                                                <state key="normal" title="StringPicker"/>
+                                                <state key="normal" title="StringPicker">
+                                                    <color key="titleColor" systemColor="linkColor"/>
+                                                </state>
                                                 <connections>
                                                     <action selector="tappedStringPickerButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="5xj-Qd-gOe"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3WS-pM-a3Z">
+                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3WS-pM-a3Z">
                                                 <rect key="frame" x="0.0" y="44" width="162" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="iJm-iE-Ojl"/>
                                                 </constraints>
-                                                <state key="normal" title="StringPicker with Image"/>
+                                                <state key="normal" title="StringPicker with Image">
+                                                    <color key="titleColor" systemColor="linkColor"/>
+                                                </state>
                                                 <connections>
                                                     <action selector="didTapStringPickerWithImageButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="GzE-iy-hjk"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZLL-IA-ugZ" userLabel="StringPicker Clearable">
-                                                <rect key="frame" x="5" y="88" width="152" height="30"/>
-                                                <state key="normal" title="StringPicker Clearable"/>
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="ZLL-IA-ugZ" userLabel="StringPicker Clearable">
+                                                <rect key="frame" x="4.5" y="88" width="153" height="30"/>
+                                                <state key="normal" title="StringPicker Clearable">
+                                                    <color key="titleColor" systemColor="linkColor"/>
+                                                </state>
                                                 <connections>
                                                     <action selector="didTapStringPickerClearableButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="eCu-rx-nia"/>
                                                 </connections>
@@ -62,7 +67,6 @@
                                             <constraint firstAttribute="height" constant="32" id="KBJ-Q8-ZUB"/>
                                             <constraint firstAttribute="width" constant="200" id="ett-0f-LZ7"/>
                                         </constraints>
-                                        <nil key="textColor"/>
                                         <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                         <textInputTraits key="textInputTraits"/>
                                         <connections>
@@ -72,7 +76,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="xb6-im-pvz" userLabel="ColumnStringPicker Stack View">
                                         <rect key="frame" x="115.5" y="170" width="144" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dyw-Xo-Who">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="Dyw-Xo-Who">
                                                 <rect key="frame" x="0.0" y="0.0" width="144" height="44"/>
                                                 <state key="normal" title="ColumnsStringPicker"/>
                                                 <connections>
@@ -88,7 +92,7 @@
                                         <rect key="frame" x="0.0" y="224" width="375" height="70"/>
                                         <subviews>
                                             <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="collectionView" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="zpQ-gA-FQa">
-                                                <rect key="frame" x="132.5" y="0.0" width="110.5" height="24"/>
+                                                <rect key="frame" x="132.5" y="0.0" width="110" height="24"/>
                                                 <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                 <nil key="textColor"/>
                                                 <nil key="highlightedColor"/>
@@ -107,7 +111,7 @@
                                                     <inset key="sectionInset" minX="0.0" minY="0.0" maxX="0.0" maxY="0.0"/>
                                                 </collectionViewFlowLayout>
                                                 <cells>
-                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" misplaced="YES" reuseIdentifier="Cell" id="tPz-UL-PSM">
+                                                    <collectionViewCell opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" reuseIdentifier="Cell" id="tPz-UL-PSM">
                                                         <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                         <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                         <view key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center">
@@ -115,6 +119,7 @@
                                                             <autoresizingMask key="autoresizingMask"/>
                                                             <subviews>
                                                                 <label opaque="NO" userInteractionEnabled="NO" tag="1" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" text="Label" textAlignment="center" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="WGq-v7-9Vx">
+                                                                    <rect key="frame" x="0.0" y="0.0" width="44" height="44"/>
                                                                     <fontDescription key="fontDescription" type="system" pointSize="17"/>
                                                                     <color key="textColor" red="0.0" green="0.47843137250000001" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                                                                     <nil key="highlightedColor"/>
@@ -142,7 +147,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="QZp-iL-6BW" userLabel="DatePicker Stack View">
                                         <rect key="frame" x="99.5" y="304" width="176" height="132"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0f-NN-ctD">
+                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="249" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="S0f-NN-ctD">
                                                 <rect key="frame" x="0.0" y="0.0" width="176" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="AGl-fP-8rd"/>
@@ -152,7 +157,7 @@
                                                     <action selector="tappendDatePickerButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="vd3-AN-0Bx"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2Y-eM-ogW">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="H2Y-eM-ogW">
                                                 <rect key="frame" x="0.0" y="44" width="176" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="0hC-Of-Fdv"/>
@@ -162,7 +167,7 @@
                                                     <action selector="tappendDatePickerCanClearButton:" destination="BYZ-38-t0r" eventType="touchUpInside" id="ayG-uu-hAz"/>
                                                 </connections>
                                             </button>
-                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ks-c5-B6c">
+                                            <button opaque="NO" contentMode="scaleToFill" verticalHuggingPriority="251" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="7Ks-c5-B6c">
                                                 <rect key="frame" x="0.0" y="88" width="176" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="bAu-np-Sn0"/>
@@ -177,7 +182,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="qa5-lZ-Dlo" userLabel="CountdownPicker Stack View">
                                         <rect key="frame" x="148" y="446" width="79" height="44"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r3c-rj-dZy">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="left" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="r3c-rj-dZy">
                                                 <rect key="frame" x="0.0" y="0.0" width="79" height="44"/>
                                                 <constraints>
                                                     <constraint firstAttribute="height" constant="44" id="kyL-I3-bMM"/>
@@ -192,7 +197,7 @@
                                     <stackView opaque="NO" contentMode="scaleToFill" axis="vertical" translatesAutoresizingMaskIntoConstraints="NO" id="Oik-2c-Psu" userLabel="Table View Stack View">
                                         <rect key="frame" x="150.5" y="500" width="74" height="30"/>
                                         <subviews>
-                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="roundedRect" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3a5-xH-6yM">
+                                            <button opaque="NO" contentMode="scaleToFill" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="3a5-xH-6yM">
                                                 <rect key="frame" x="0.0" y="0.0" width="74" height="30"/>
                                                 <state key="normal" title="Table View"/>
                                                 <connections>
@@ -207,7 +212,7 @@
                                 </constraints>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="EQM-gH-Hgi" firstAttribute="top" secondItem="y3c-jy-aDJ" secondAttribute="bottom" id="hE1-ag-gL1"/>
                             <constraint firstAttribute="trailing" secondItem="EQM-gH-Hgi" secondAttribute="trailing" id="iic-dh-Oyz"/>
@@ -227,10 +232,10 @@
                     <tableView key="view" clipsSubviews="YES" contentMode="scaleToFill" alwaysBounceVertical="YES" dataMode="prototypes" style="grouped" separatorStyle="default" allowsSelection="NO" rowHeight="-1" estimatedRowHeight="-1" sectionHeaderHeight="18" sectionFooterHeight="18" id="aAW-JA-RQr">
                         <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
-                        <color key="backgroundColor" cocoaTouchSystemColor="groupTableViewBackgroundColor"/>
+                        <color key="backgroundColor" systemColor="groupTableViewBackgroundColor"/>
                         <prototypes>
                             <tableViewCell clipsSubviews="YES" contentMode="scaleToFill" preservesSuperviewLayoutMargins="YES" selectionStyle="default" indentationWidth="10" reuseIdentifier="textFieldCell" id="zyi-9g-4RJ" customClass="TextFieldCell" customModule="SwiftyPickerPopoverDemo" customModuleProvider="target">
-                                <rect key="frame" x="0.0" y="55.5" width="375" height="44"/>
+                                <rect key="frame" x="0.0" y="49.5" width="375" height="43.5"/>
                                 <autoresizingMask key="autoresizingMask"/>
                                 <tableViewCellContentView key="contentView" opaque="NO" clipsSubviews="YES" multipleTouchEnabled="YES" contentMode="center" preservesSuperviewLayoutMargins="YES" insetsLayoutMarginsFromSafeArea="NO" tableViewCell="zyi-9g-4RJ" id="KGY-Eh-63M">
                                     <rect key="frame" x="0.0" y="0.0" width="375" height="43.5"/>
@@ -254,7 +259,7 @@
                 <navigationController automaticallyAdjustsScrollViewInsets="NO" id="clX-j4-gDi" sceneMemberID="viewController">
                     <toolbarItems/>
                     <navigationBar key="navigationBar" contentMode="scaleToFill" insetsLayoutMarginsFromSafeArea="NO" id="XlC-bt-1b5">
-                        <rect key="frame" x="0.0" y="20" width="375" height="44"/>
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="44"/>
                         <autoresizingMask key="autoresizingMask"/>
                         <color key="barTintColor" red="1" green="0.49327188729999999" blue="0.47399842739999998" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                         <textAttributes key="titleTextAttributes">
@@ -271,4 +276,15 @@
             <point key="canvasLocation" x="304.80000000000001" y="356.67166416791605"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="groupTableViewBackgroundColor">
+            <color red="0.94901960784313721" green="0.94901960784313721" blue="0.96862745098039216" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/Demo/LaunchScreen.storyboard
+++ b/Demo/LaunchScreen.storyboard
@@ -1,7 +1,9 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="11134" systemVersion="15F34" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <device id="retina6_1" orientation="portrait" appearance="light"/>
     <dependencies>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="11106"/>
+        <deployment identifier="iOS"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -14,7 +16,7 @@
                         <viewControllerLayoutGuide type="bottom" id="xb3-aO-Qok"/>
                     </layoutGuides>
                     <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
-                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <rect key="frame" x="0.0" y="0.0" width="414" height="896"/>
                         <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
                         <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
                     </view>

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.5
 // The swift-tools-version declares the minimum version of Swift required to build this package.
 
 import PackageDescription

--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "SwiftyPickerPopover",
     defaultLocalization: "en",
     platforms: [
-        .iOS(.v9),
+        .iOS(.v14),
     ],
     products: [
         // Products define the executables and libraries produced by a package, and make them visible to other packages.

--- a/SwiftyPickerPopover/AbstractPopover.storyboard
+++ b/SwiftyPickerPopover/AbstractPopover.storyboard
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="tx8-1P-8by">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="tx8-1P-8by">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17124"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>

--- a/SwiftyPickerPopover/Base.lproj/CountdownPickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/CountdownPickerPopover.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -59,7 +60,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="0l0-Ib-qwY" firstAttribute="top" secondItem="cbG-vC-cwF" secondAttribute="bottom" id="B6X-eD-jtj"/>
                             <constraint firstItem="0l0-Ib-qwY" firstAttribute="leading" secondItem="wcv-6k-DXR" secondAttribute="leading" id="KWB-eI-Gkt"/>
@@ -92,4 +93,9 @@
             <point key="canvasLocation" x="-196" y="-412"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/DatePickerPopover.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17156" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="byJ-Vv-M5N">
     <device id="retina5_5" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17125"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -58,7 +59,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="KrY-U2-tGZ" firstAttribute="top" secondItem="R5c-bl-QZD" secondAttribute="bottom" id="X0f-NI-jfK"/>
                             <constraint firstAttribute="trailing" secondItem="R5c-bl-QZD" secondAttribute="trailing" id="mBW-0J-TSp"/>
@@ -92,4 +93,9 @@
             <point key="canvasLocation" x="-196" y="-422"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
+++ b/SwiftyPickerPopover/Base.lproj/StringPickerPopover.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17124"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -43,10 +44,13 @@
                                 <subviews>
                                     <pickerView contentMode="scaleToFill" verticalHuggingPriority="249" translatesAutoresizingMaskIntoConstraints="NO" id="tJe-Py-ArN">
                                         <rect key="frame" x="0.0" y="0.0" width="375" height="623"/>
+                                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                                     </pickerView>
                                     <button opaque="NO" contentMode="scaleToFill" placeholderIntrinsicWidth="300" placeholderIntrinsicHeight="44" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="j9H-Vq-pbw">
                                         <rect key="frame" x="0.0" y="623" width="375" height="44"/>
-                                        <state key="normal" title="Clear"/>
+                                        <state key="normal" title="Clear">
+                                            <color key="titleColor" systemColor="linkColor"/>
+                                        </state>
                                         <connections>
                                             <action selector="tappedClear:" destination="pEv-eJ-a7K" eventType="touchUpInside" id="Xkg-Mh-xgO"/>
                                         </connections>
@@ -54,7 +58,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="oa7-FA-D0J" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="9AD-ca-pud"/>
                             <constraint firstAttribute="trailing" secondItem="oa7-FA-D0J" secondAttribute="trailing" id="Qjj-t5-GDS"/>
@@ -88,4 +92,12 @@
             <point key="canvasLocation" x="405" y="799"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="linkColor">
+            <color red="0.0" green="0.47843137254901963" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+        </systemColor>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftyPickerPopover/ColumnStringPickerPopover.storyboard
+++ b/SwiftyPickerPopover/ColumnStringPickerPopover.storyboard
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="17154" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="19529" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" colorMatched="YES" initialViewController="Vlu-nf-qJc">
     <device id="retina4_7" orientation="portrait" appearance="light"/>
     <dependencies>
         <deployment identifier="iOS"/>
-        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="17124"/>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="19519"/>
+        <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
     </dependencies>
     <scenes>
@@ -53,7 +54,7 @@
                                 </subviews>
                             </stackView>
                         </subviews>
-                        <color key="backgroundColor" red="1" green="1" blue="1" alpha="1" colorSpace="custom" customColorSpace="sRGB"/>
+                        <color key="backgroundColor" systemColor="systemBackgroundColor"/>
                         <constraints>
                             <constraint firstItem="bBN-ZK-3Ap" firstAttribute="top" secondItem="cBE-9P-52d" secondAttribute="top" id="1jT-5j-g09"/>
                             <constraint firstAttribute="trailing" secondItem="bBN-ZK-3Ap" secondAttribute="trailing" id="Jve-Wb-ug1"/>
@@ -87,4 +88,9 @@
             <point key="canvasLocation" x="405" y="799"/>
         </scene>
     </scenes>
+    <resources>
+        <systemColor name="systemBackgroundColor">
+            <color white="1" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+        </systemColor>
+    </resources>
 </document>

--- a/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/ColumnStringPickerPopoverViewController.swift
@@ -40,13 +40,6 @@ public class ColumnStringPickerPopoverViewController: AbstractPickerPopoverViewC
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
         
-        // Set up cancel button
-        if #available(iOS 11.0, *) {}
-        else {
-            navigationItem.leftBarButtonItem = nil
-            navigationItem.rightBarButtonItem = nil
-        }
-        
         // Select rows if needed
         popover.selectedRows.enumerated().forEach {
             picker.selectRow($0.element, inComponent: $0.offset, animated: true)

--- a/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/CountdownPickerPopoverViewController.swift
@@ -26,11 +26,6 @@ public class CountdownPickerPopoverViewController: AbstractPickerPopoverViewCont
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        if #available(iOS 11.0, *) { }
-        else {
-            navigationItem.leftBarButtonItem = nil
-            navigationItem.rightBarButtonItem = nil
-        }
         cancelButton.title = popover.cancelButton.title
         if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedString.Key.font: font], for: .normal)

--- a/SwiftyPickerPopover/DatePickerPopover.swift
+++ b/SwiftyPickerPopover/DatePickerPopover.swift
@@ -36,7 +36,6 @@ public class DatePickerPopover: AbstractPopover {
     private(set) var dateMode_: UIDatePicker.Mode = .date
     
     /// preferred style
-    @available(iOS 13.4, *)
     private(set) lazy var preferredDatePickerStyle_: UIDatePickerStyle = .wheels
     
     /// Limit of range
@@ -82,7 +81,6 @@ public class DatePickerPopover: AbstractPopover {
      ///
      /// - Parameter preferredDatePickerStyle: UIDatePickerStyle of picker.
      /// - Returns: self
-     @available(iOS 13.4, *)
      public func setPreferredDatePickerStyle(_ preferredDatePickerStyle: UIDatePickerStyle)->Self{
          self.preferredDatePickerStyle_ = preferredDatePickerStyle
          return self

--- a/SwiftyPickerPopover/DatePickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/DatePickerPopoverViewController.swift
@@ -21,11 +21,6 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
     
     override func refrectPopoverProperties(){
         super.refrectPopoverProperties()
-        if #available(iOS 11.0, *) { }
-        else {
-            navigationItem.leftBarButtonItem = nil
-            navigationItem.rightBarButtonItem = nil
-        }
         cancelButton.title = popover.cancelButton.title
         if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedString.Key.font: font], for: .normal)
@@ -47,9 +42,7 @@ public class DatePickerPopoverViewController: AbstractPickerPopoverViewControlle
         clearButton.tintColor = popover.clearButton.color ?? popover.tintColor
         clearButton.isHidden = popover.clearButton.action == nil
 
-        if #available(iOS 13.4, *) {
-            picker.preferredDatePickerStyle = popover.preferredDatePickerStyle_
-        }
+        picker.preferredDatePickerStyle = popover.preferredDatePickerStyle_
         picker.date = popover.selectedDate
         picker.minimumDate = popover.minimumDate
         picker.maximumDate = popover.maximumDate

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -72,6 +72,10 @@ public class StringPickerPopover: AbstractPopover {
         // Set parameters
         self.title = title
         self.choices = choices
+        
+        if #available(iOS 13, *) {
+            fontColor = .label
+        }
     }
 
     /// Set font

--- a/SwiftyPickerPopover/StringPickerPopover.swift
+++ b/SwiftyPickerPopover/StringPickerPopover.swift
@@ -73,9 +73,7 @@ public class StringPickerPopover: AbstractPopover {
         self.title = title
         self.choices = choices
         
-        if #available(iOS 13, *) {
-            fontColor = .label
-        }
+        fontColor = .label
     }
 
     /// Set font

--- a/SwiftyPickerPopover/StringPickerPopoverViewController.swift
+++ b/SwiftyPickerPopover/StringPickerPopoverViewController.swift
@@ -36,13 +36,6 @@ public class StringPickerPopoverViewController: AbstractPickerPopoverViewControl
         // Select row if needed
         picker?.selectRow(popover.selectedRow, inComponent: 0, animated: true)
 
-        // Set up cancel button
-        if #available(iOS 11.0, *) { }
-        else {
-            navigationItem.leftBarButtonItem = nil
-            navigationItem.rightBarButtonItem = nil
-        }
-
         cancelButton.title = popover.cancelButton.title
         if let font = popover.cancelButton.font {
             cancelButton.setTitleTextAttributes([NSAttributedString.Key.font: font], for: .normal)


### PR DESCRIPTION
This PR enables dark mode support (background and text colors). It also bumps the iOS dependency target to 14.0 so we can reference the new colors safely from the Storyboard, which enables us to remove some checks for iOS <14.